### PR TITLE
Fix incorrect CSS (breaking)

### DIFF
--- a/src/lib/Notifications.svelte
+++ b/src/lib/Notifications.svelte
@@ -69,7 +69,7 @@
   .toasts > .toast > .progress {
     position: absolute;
     bottom: 0;
-    background-color: rgb(0, 0, 0, 0.3);
+    background-color: rgba(0, 0, 0, 0.3);
     height: 6px;
     width: 100%;
     animation-name: shrink;


### PR DESCRIPTION
1. Various style loaders detect incorrect css and fails.
2. Fixed invalid CSS in general.